### PR TITLE
Introduce basic logging facilities

### DIFF
--- a/lib/redis_cluster/node.rb
+++ b/lib/redis_cluster/node.rb
@@ -1,6 +1,8 @@
 module RedisCluster
 
   class Node
+    attr_accessor :options
+
     # slots is a range array: [1..100, 300..500]
     attr_accessor :slots
 
@@ -35,7 +37,7 @@ module RedisCluster
     end
 
     def connection
-      @connection ||= self.class.redis(@options)
+      @connection ||= self.class.redis(options)
     end
 
     def self.redis(options)


### PR DESCRIPTION
When things go wrong it's nice to have a little more insight into what
exactly any given library is doing. This patch introduces some basic
(and optional) logging facilities to help with this.

The most minimal approach is to enable the logger at the error level. In
this case the library will just log errors that it sees and handles.

---

Note that this targets the branch in #2 and should be retargeted and merged only after that's brought into master.